### PR TITLE
Switch CI/CD to build using ninja vs. make

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
         run:  |
           mkdir -p build
           cd build
-          cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=${{ runner.temp }}/arm-none-eabi -DNRF5_SDK_PATH=${{ runner.temp }}/nrf5_sdk -DUSE_OPENOCD=1 -DBUILD_DFU=1 ../
+          cmake -G Ninja -DARM_NONE_EABI_TOOLCHAIN_PATH=${{ runner.temp }}/arm-none-eabi -DNRF5_SDK_PATH=${{ runner.temp }}/nrf5_sdk -DUSE_OPENOCD=1 -DBUILD_DFU=1 ../
 
         #########################################################################################
         # Make and Upload DFU Package
@@ -126,7 +126,7 @@ jobs:
       - name: Make pinetime-mcuboot-app
         run:  |
           cd build
-          make pinetime-mcuboot-app
+          ninja pinetime-mcuboot-app
 
       - name: Unzip DFU package
         run:  |
@@ -145,7 +145,7 @@ jobs:
       - name: Make pinetime-app
         run:  |
           cd build
-          make pinetime-app
+          ninja pinetime-app
 
       - name: Upload standalone firmware
         uses: actions/upload-artifact@v2
@@ -159,7 +159,7 @@ jobs:
       - name: Make pinetime-recovery
         run:  |
           cd build
-          make pinetime-recovery
+          ninja pinetime-recovery
 
       #########################################################################################
       # Finish


### PR DESCRIPTION
By switching the CI/CD workflow to use CMake's `ninja` backend, the build time goes down considerably (~4.5 minutes to ~2) compared to GNU Make